### PR TITLE
Ajouter le serveur Paris 1 Panthéon-Sorbonne

### DIFF
--- a/src/main/assets/urls
+++ b/src/main/assets/urls
@@ -11,3 +11,4 @@ https://nfc-tag.unimes.fr
 https://esup-nfc-tag.normandie-univ.fr
 https://esup-nfc-tag.univ-amu.fr
 https://esup-nfc-tag-test.univ-amu.fr
+https://esupnfctag.univ-paris1.fr


### PR DESCRIPTION
Veuillez SVP ajouter le serveur de l'Université Paris 1 Panthéon-Sorbonne dans l'application officielle EsupNfcTagDroid.